### PR TITLE
Database

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -2,6 +2,7 @@
   "name": "brokerhub",
   "version": "0.1.0",
   "private": true,
+  "proxy": "http://localhost:3001/",
   "dependencies": {
     "react": "^16.2.0",
     "react-dom": "^16.2.0",

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import axios from 'axios';
 import { BrowserRouter as Router, Route } from 'react-router-dom';
 import Main from "./components/pages/Main";
 import Search from "./components/pages/Search";
@@ -10,6 +11,11 @@ import Navbar from "./components/Navbar/Navbar";
 import SideNav from "./components/SideNav/SideNav";
      
 class App extends Component {
+
+  componentDidMount() {
+    axios.get("/api/users")
+  }
+
 render() {
 return (
       <Router>

--- a/controllers/userController.js
+++ b/controllers/userController.js
@@ -4,6 +4,7 @@ const db = require("../models");
 
 module.exports = {
   findAll: function(req, res) {
+    console.log('/user routes')
     db.Users
       .find(req.query)
       .sort({ date: -1 })

--- a/server.js
+++ b/server.js
@@ -25,5 +25,5 @@ mongoose.connect(
 
 // Start the API server
 app.listen(PORT, function() {
-  console.log(`🌎  ==> API Server now listening on PORT ${PORT}!`);
+  console.log(`🌎  ==> API Server now listening on PORT ${PORT}!`, "Hi, Clark!");
 });


### PR DESCRIPTION
Solved longstanding API call issue. Create React App hogs up all ports on Localhost:3000. You need to create a proxy server instantiated in Client/package.json, and then use Axios (Import axios from 'axios'), with State in React for making API Calls. Also, you can instantiate an API.js file under utilities (look at nyt-scraper-react-mongo for examples).


Changes to App.js
Instantiated Axios in App.js file.